### PR TITLE
Update expired invite link + contract url

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The project was started as an experiment by [Nader Dabit](https://twitter.com/da
 
 ## How do I join?
 
-The DAO operates inside our [discord server](https://twitter.com/dabit3). To gain access to this server you need to own a [Devs for Revolution](https://opensea.io/collection/devs-for-revolution) NFT. The contract for purchasing one [can be found on etherscan.io](https://etherscan.io/token/0x25ed58c027921e14d86380ea2646e3a1b5c55a8b). If you're not sure how to mint an NFT, [check out this how-to article](https://jonkuperman.com/how-to-join-developer-dao/) by @jkup.
+The DAO operates inside our [discord server](https://discord.gg/ASjBPJuNhS). To gain access to this server you need to own a [Devs for Revolution](https://opensea.io/collection/devs-for-revolution) NFT. The contract for purchasing one [can be found on etherscan.io](https://etherscan.io/address/0x25ed58c027921e14d86380ea2646e3a1b5c55a8b#writeContract). If you're not sure how to mint an NFT, [check out this how-to article](https://jonkuperman.com/how-to-join-developer-dao/) by @jkup.
 
 Whilst there is no charge for the NFT you will have to pay a "gas fee" for the Ethereum Blockchain network in order to mint one. This fee can range wildy from about $40 up to and over $400 at peak times. You can check current gas fee uisng the [Etherum gas price tracker](https://etherscan.io/gastracker). If the fee is high you may want to wait and come back later. 
 
@@ -85,5 +85,5 @@ Thanks for showing interest in contributing to DeveloperDAO. Before submitting a
   <img src="https://contrib.rocks/image?repo=developer-dao/developer-dao" />
 </a>
 
-[Discord]: https://discord.gg/ZHZup79J
+[Discord]: https://discord.gg/ASjBPJuNhS
 


### PR DESCRIPTION
The original invite link had expired so update with new one set to never expire and unlimited uses.

Also updated contract `url` to go straight to where you mint the NFT rather than D4R address.