### PR TITLE
Added french translation for enterDeveloperId in fr/translations.js

### DIFF
--- a/src/locales/fr/translations.js
+++ b/src/locales/fr/translations.js
@@ -4,4 +4,5 @@ export default {
   error: "Erreur",
   madeBy: "Réalisé par la communauté des développeurs DAO: ",
   owner: "Propriétaire",
+  enterDeveloperId: "Veuillez remplir le champ avec un id DAO du développeur",
 };


### PR DESCRIPTION
**Context:**
New `translation.enterDeveloperId` attribute was introduced and this is the French translation of that field.