### PR TITLE
Added default gray to body instead of section

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
     -->
     <title>Developer DAO</title>
   </head>
-  <body>
+  <body class="bg-gray-50">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <!--

--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ function App() {
 
   return (
     <>
-      <section className="text-gray-600 body-font bg-gray-50">
+      <section className="text-gray-600 body-font">
         <div className="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
           <img
             src={logo}


### PR DESCRIPTION
**Context:**
Noticed when looking at the website at first load, it shows a white background when no id has been entered.
This is to address this to make sure the background is set on the `body` for the entire page.

**Before**
White at the bottom.
<img width="1413" alt="Screen Shot 2021-09-11 at 12 52 54 PM" src="https://user-images.githubusercontent.com/318082/132955349-b587da64-514b-4b2b-bf91-8ed6f1100ac6.png">

**Proposal:**
No more white at the bottom.
<img width="1413" alt="Screen Shot 2021-09-11 at 12 52 39 PM" src="https://user-images.githubusercontent.com/318082/132955353-5cc758d0-e897-41f2-ba2b-1d45c9af8b87.png">
