### PR TITLE
chore: create "missing translations" issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-translations.yml
+++ b/.github/ISSUE_TEMPLATE/missing-translations.yml
@@ -1,0 +1,34 @@
+name: 'Missing Translations'
+description: 'File a report for translations that need to be added'
+title: 'Missing Translation(s)'
+labels: ['translation']
+body:
+  - type: 'input'
+    id: 'pr-number'
+    attributes:
+      label: 'PR #'
+      description: 'The # of the PR that the translations were added in'
+    validations:
+      required: true
+  - type: 'input'
+    id: 'keys'
+    attributes:
+      label: 'Translation Keys'
+      description: 'Comma-separated list of missing translation keys'
+      placeholder: 'title, loading, error'
+    validations:
+      required: true
+  - type: 'dropdown'
+    id: 'missing-locales'
+    attributes:
+      label: 'List of missing locales'
+      description: 'Check the locales that are missing translations'
+      options:
+        - 'en'
+        - 'es'
+        - 'fr'
+        - 'ru'
+        - 'zh-CN'
+        - 'zh-HK'
+        - 'zh-TW'
+        - 'zh'


### PR DESCRIPTION
This PR adds an issue form for filing "missing translations" reports. 

Fields:
- `input` for "PR #"
	- so translators can understand the context of the changes that added the translations
- `input` for "Translation Keys"
	- comma-separated list of translation keys so translators know what's missing for their language
- `dropdown` for "List of missing locales"
	- so translators know if their language needs translated

---

Spawned from some discussion about the missing translation process in #79.

My thinking here is that this is the first step towards automating missing translations. 

Manual reports -> GitHub bot that monitors PRs and creates issues for missing keys/locales -> "Missing translation" dashboard on the site created by reading open `translation`-labeled issues

Lots of possibilities but for now this gives us a way to start tracking and organizing what's missing.