### PR TITLE
chore: make "missing translations" locales multiselect

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-translations.yml
+++ b/.github/ISSUE_TEMPLATE/missing-translations.yml
@@ -22,6 +22,7 @@ body:
     id: 'missing-locales'
     attributes:
       label: 'List of missing locales'
+      multiple: true
       description: 'Check the locales that are missing translations'
       options:
         - 'en'


### PR DESCRIPTION
This PR makes the `missing-locales` a multiselect so we can choose multiple locales for missing translations in the same report.