### PR TITLE
Added i18n support to SEO meta tags

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "title": "Developer DAO",
   "searchId": "Search Developer DAO id",
+  "description": "A community of builders who believe in collective ownership of the internet.",
   "loading": "Loading...",
   "error": "Error",
   "madeBy": "Made by the Developer DAO community: ",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,4 +1,5 @@
 {
+  "description": "Una comunidad de constructores que creen en la propiedad colectiva de Internet.",
   "searchId": "Buscar Developer DAO id",
   "loading": "Cargando...",
   "error": "Error",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1,4 +1,5 @@
 {
+  "title": "Developer DAO",
   "description": "Una comunidad de constructores que creen en la propiedad colectiva de Internet.",
   "searchId": "Buscar Developer DAO id",
   "loading": "Cargando...",

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -20,7 +20,6 @@ function SEO() {
       <link rel="icon" href="DeveloperDaoFavicon.ico" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta name="theme-color" content="#000000" />
-      <meta name="description" content={t('description')} />
       {/* Primary Meta Tags */}
       <title>{t('title')}</title>
       <meta name="title" content={t('title')} />

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -2,45 +2,37 @@ import React from 'react';
 import Head from 'next/head';
 import { appWithTranslation } from 'next-i18next';
 import { ChakraProvider } from '@chakra-ui/react';
-import { theme } from '../theme';
+import { useTranslation } from 'next-i18next';
 import '@fontsource/inter/variable-full.css';
 import '@fontsource/source-code-pro/400.css';
 
+import { theme } from '../theme';
+
 function SEO() {
+  const { t } = useTranslation();
+
   return (
     <Head>
       <meta charSet="utf-8" />
       <link rel="icon" href="DeveloperDaoFavicon.ico" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta name="theme-color" content="#000000" />
-      <meta
-        name="description"
-        content="A community of builders who believe in collective ownership of the internet."
-      />
+      <meta name="description" content={t('description')} />
       {/* Primary Meta Tags */}
       <title>Developer DAO</title>
       <meta name="title" content="Developer DAO" />
-      <meta
-        name="description"
-        content="A community of builders who believe in collective ownership of the internet."
-      />
+      <meta name="description" content={t('description')} />
       {/* Open Graph / Facebook */}
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://www.developerdao.com/" />
       <meta property="og:title" content="Developer DAO" />
-      <meta
-        property="og:description"
-        content="A community of builders who believe in collective ownership of the internet."
-      />
+      <meta property="og:description" content={t('description')} />
       <meta property="og:image" content="social-banner.png" />
       {/* Twitter */}
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content="https://www.developerdao.com/" />
       <meta property="twitter:title" content="Developer DAO" />
-      <meta
-        property="twitter:description"
-        content="A community of builders who believe in collective ownership of the internet."
-      />
+      <meta property="twitter:description" content={t('description')} />
       <meta property="twitter:image" content="social-banner.png" />
       {/* Favicon Images */}
       <link rel="apple-touch-icon" href="logo192.png" />

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -22,19 +22,19 @@ function SEO() {
       <meta name="theme-color" content="#000000" />
       <meta name="description" content={t('description')} />
       {/* Primary Meta Tags */}
-      <title>Developer DAO</title>
-      <meta name="title" content="Developer DAO" />
+      <title>{t('title')}</title>
+      <meta name="title" content={t('title')} />
       <meta name="description" content={t('description')} />
       {/* Open Graph / Facebook */}
       <meta property="og:type" content="website" />
       <meta property="og:url" content="https://www.developerdao.com/" />
-      <meta property="og:title" content="Developer DAO" />
+      <meta property="og:title" content={t('title')} />
       <meta property="og:description" content={t('description')} />
       <meta property="og:image" content={socialBanner} />
       {/* Twitter */}
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content="https://www.developerdao.com/" />
-      <meta property="twitter:title" content="Developer DAO" />
+      <meta property="twitter:title" content={t('title')} />
       <meta property="twitter:description" content={t('description')} />
       <meta property="twitter:image" content={socialBanner} />
       {/* Favicon Images */}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -6,7 +6,10 @@ import { useTranslation } from 'next-i18next';
 import '@fontsource/inter/variable-full.css';
 import '@fontsource/source-code-pro/400.css';
 
+import { DEVELOPER_DAO_WEBSITE } from '../utils/DeveloperDaoConstants';
 import { theme } from '../theme';
+
+const socialBanner = `${DEVELOPER_DAO_WEBSITE}/social-banner.png`;
 
 function SEO() {
   const { t } = useTranslation();
@@ -27,13 +30,13 @@ function SEO() {
       <meta property="og:url" content="https://www.developerdao.com/" />
       <meta property="og:title" content="Developer DAO" />
       <meta property="og:description" content={t('description')} />
-      <meta property="og:image" content="social-banner.png" />
+      <meta property="og:image" content={socialBanner} />
       {/* Twitter */}
       <meta property="twitter:card" content="summary_large_image" />
       <meta property="twitter:url" content="https://www.developerdao.com/" />
       <meta property="twitter:title" content="Developer DAO" />
       <meta property="twitter:description" content={t('description')} />
-      <meta property="twitter:image" content="social-banner.png" />
+      <meta property="twitter:image" content={socialBanner} />
       {/* Favicon Images */}
       <link rel="apple-touch-icon" href="logo192.png" />
       <link

--- a/src/utils/DeveloperDaoConstants.js
+++ b/src/utils/DeveloperDaoConstants.js
@@ -1,5 +1,6 @@
 export const DEVELOPER_DAO_CONTRACT =
   '0x25ed58c027921E14D86380eA2646E3a1B5C55A8b';
+export const DEVELOPER_DAO_WEBSITE = 'https://www.developerdao.com';
 export const OPENSEA_DIRECT_LINK_PREFIX = `https://opensea.io/assets/${DEVELOPER_DAO_CONTRACT}`;
 export const ETHER_SCAN_LINK_PREFIX = 'https://etherscan.io/address';
 export const SITE_URL = 'https://developerdao.com';


### PR DESCRIPTION
Closes #63 

- Moved SEO title and description meta tags to translation files
- Removed duplicate description meta tag
- Added Spanish translation for the page description (proofread wanted ⚠️ )
- Changed social banner meta tag for absolute URL so it can be displayed properly on Twitter

Preview on Facebook Debugger:
![Screen Shot 2021-09-19 at 12 14 40 AM](https://user-images.githubusercontent.com/3985462/133914228-c7570526-3063-4fe2-bf57-3f7dbc0723d0.png)

Preview on Twitter Card Validator:
![Screen Shot 2021-09-19 at 12 15 24 AM](https://user-images.githubusercontent.com/3985462/133914241-bce0e4a0-96e3-41fa-b45b-16b096462b56.png)