### PR TITLE
test: create `react-i18next` manual mock

### DIFF
--- a/__mocks__/react-i18next.js
+++ b/__mocks__/react-i18next.js
@@ -1,0 +1,3 @@
+module.exports = {
+  useTranslation: () => ({ t: (key) => key }),
+};

--- a/_tests_/Footer/index.test.jsx
+++ b/_tests_/Footer/index.test.jsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Footer from '../../src/components/Footer/index';
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key) => key }),
-}));
-
 describe('Footer', () => {
   it('Renders the github link', () => {
     render(<Footer />);

--- a/_tests_/Nav/index.test.jsx
+++ b/_tests_/Nav/index.test.jsx
@@ -3,10 +3,6 @@ import { render, screen } from '@testing-library/react';
 import Nav from '../../src/components/Nav/index';
 import testCommonLink from '../utils/testCommons';
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key) => key }),
-}));
-
 describe('Nav', () => {
   it('Renders the github link', () => {
     render(<Nav />);

--- a/_tests_/pages/index.test.jsx
+++ b/_tests_/pages/index.test.jsx
@@ -8,10 +8,6 @@ import {
 } from '../../src/utils/DeveloperDaoConstants';
 import { ownedDeveloperNFT, unownedDeveloperNFT } from '../mocks/DeveloperNFT';
 
-jest.mock('react-i18next', () => ({
-  useTranslation: () => ({ t: (key) => key }),
-}));
-
 const useRouter = jest
   .spyOn(require('next/router'), 'useRouter')
   .mockImplementation(() => ({


### PR DESCRIPTION
### What does it do?

Creates a [`jest` manual mock](https://jestjs.io/docs/manual-mocks) for `react-i18next`. Since we'll need to mock out `useTranslation` in a lot of our components, creating this manual mock means it will automatically be mocked for all of them.

cc @narbs91 